### PR TITLE
change: remove metodos virtuais do denunciavel

### DIFF
--- a/src/dominio/identidade/entidades/usuario.cpp
+++ b/src/dominio/identidade/entidades/usuario.cpp
@@ -15,15 +15,6 @@ Usuario::Usuario(std::string nome_,
 {
 }
 
-const std::string& Usuario::obtenhaId() const
-{
-    return this->id;
-}
-Moderacao::Enums::TipoDoDenunciavel Usuario::obtenhaTipo() const
-{
-    return this->tipo;
-}
-
 const std::string* Usuario::obtenhaNome() const
 {
     return &this->nome;

--- a/src/dominio/identidade/entidades/usuario.hpp
+++ b/src/dominio/identidade/entidades/usuario.hpp
@@ -26,9 +26,6 @@ class Usuario : public Moderacao::Entidades::Denunciavel
             time_t dataDeNascimento,
             Cargo cargo);
 
-    const std::string& obtenhaId() const override;
-    Moderacao::Enums::TipoDoDenunciavel obtenhaTipo() const override;
-
     const std::string* obtenhaNome() const;
     const std::string* obtenhaEmail() const;
     const std::string* obtenhaHashDaSeha() const;

--- a/src/dominio/moderacao/entidades/denunciavel.cpp
+++ b/src/dominio/moderacao/entidades/denunciavel.cpp
@@ -11,4 +11,14 @@ Denunciavel::Denunciavel(Enums::TipoDoDenunciavel tipo_) : tipo(tipo_)
     this->id = std::move(strUuid);
 }
 
+const std::string& Denunciavel::obtenhaId() const
+{
+    return this->id;
+}
+
+Moderacao::Enums::TipoDoDenunciavel Denunciavel::obtenhaTipo() const
+{
+    return this->tipo;
+}
+
 } // namespace Moderacao::Entidades

--- a/src/dominio/moderacao/entidades/denunciavel.hpp
+++ b/src/dominio/moderacao/entidades/denunciavel.hpp
@@ -15,8 +15,8 @@ class Denunciavel
     Denunciavel(Enums::TipoDoDenunciavel tipo);
 
   public:
-    virtual const std::string& obtenhaId() const = 0;
-    virtual Enums::TipoDoDenunciavel obtenhaTipo() const = 0;
+    const std::string& obtenhaId() const;
+    Enums::TipoDoDenunciavel obtenhaTipo() const;
 
     virtual ~Denunciavel() = default;
 };


### PR DESCRIPTION
Substitui os métodos getters virtuais por métodos normais, já que não havia razão pra serem virtuais (não vão ser sobrescritos depois).