### PR TITLE
refactor: adiciona métodos auxiliares

### DIFF
--- a/src/dominio/feed/entidades/comentavel.cpp
+++ b/src/dominio/feed/entidades/comentavel.cpp
@@ -1,4 +1,5 @@
 #include "comentavel.hpp"
+#include "util/datas.hpp"
 #include <chrono>
 
 namespace Feed::Entidades
@@ -7,16 +8,9 @@ namespace Feed::Entidades
 Comentavel::Comentavel(std::string conteudo_,
                        Moderacao::Enums::TipoDoDenunciavel tipo)
     : Moderacao::Entidades::Denunciavel(tipo), conteudo(std::move(conteudo_)),
-      dataPublicacao(Comentavel::obtenhaDataAtual())
+      dataPublicacao(Utils::DataHora::obtenhaDataHoraAtual())
 
 {
-}
-
-time_t Comentavel::obtenhaDataAtual()
-{
-    auto now = std::chrono::system_clock::now();
-    auto nowTimeT = std::chrono::system_clock::to_time_t(now);
-    return nowTimeT;
 }
 
 const std::string& Comentavel::obtenhaConteudo() const
@@ -41,7 +35,7 @@ const std::optional<time_t>& Comentavel::obtenhaDataRemocao() const
 
 void Comentavel::desativar()
 {
-    this->dataRemocao = Comentavel::obtenhaDataAtual();
+    this->dataRemocao = Utils::DataHora::obtenhaDataHoraAtual();
     this->estaAtivo = false;
 }
 

--- a/src/dominio/feed/entidades/comentavel.hpp
+++ b/src/dominio/feed/entidades/comentavel.hpp
@@ -17,9 +17,6 @@ class Comentavel : public Moderacao::Entidades::Denunciavel
     std::optional<time_t> dataRemocao;
     bool estaAtivo = true;
 
-  private:
-    static time_t obtenhaDataAtual();
-
   public:
     const std::string& obtenhaConteudo() const;
     time_t obtenhaDataPublicacao() const;

--- a/src/dominio/moderacao/entidades/denuncia.cpp
+++ b/src/dominio/moderacao/entidades/denuncia.cpp
@@ -1,5 +1,5 @@
 #include "denuncia.hpp"
-#include <boost/uuid.hpp>
+#include "util/id.hpp"
 
 namespace Moderacao::Entidades
 {
@@ -9,12 +9,11 @@ Denuncia::Denuncia(std::optional<std::string> detalhes_,
                    Enums::EstadoDaDenuncia estado_,
                    std::shared_ptr<Identidade::Entidades::Usuario> relator_,
                    std::shared_ptr<Denunciavel> denunciavel_)
-    : detalhes(std::move(detalhes_)), motivo(motivo_), estado(estado_),
-      relator(std::move(relator_)), denunciavel(std::move(denunciavel_))
+    : id(Utils::GeradorDeId::gerarUUID()), detalhes(std::move(detalhes_)),
+      motivo(motivo_), estado(estado_), relator(std::move(relator_)),
+      denunciavel(std::move(denunciavel_))
+
 {
-    boost::uuids::random_generator uuidGenerator;
-    std::string strUuid = boost::uuids::to_string(uuidGenerator());
-    this->id = std::move(strUuid);
 }
 
 const std::string& Denuncia::obtenhaId() const

--- a/src/dominio/moderacao/entidades/denunciavel.cpp
+++ b/src/dominio/moderacao/entidades/denunciavel.cpp
@@ -1,14 +1,12 @@
 #include "denunciavel.hpp"
-#include <boost/uuid.hpp>
+#include "util/id.hpp"
 
 namespace Moderacao::Entidades
 {
 
-Denunciavel::Denunciavel(Enums::TipoDoDenunciavel tipo_) : tipo(tipo_)
+Denunciavel::Denunciavel(Enums::TipoDoDenunciavel tipo_)
+    : id(Utils::GeradorDeId::gerarUUID()), tipo(tipo_)
 {
-    boost::uuids::random_generator uuidGenerator;
-    std::string strUuid = boost::uuids::to_string(uuidGenerator());
-    this->id = std::move(strUuid);
 }
 
 const std::string& Denunciavel::obtenhaId() const

--- a/src/dominio/terrenos/entidades/plantacao.cpp
+++ b/src/dominio/terrenos/entidades/plantacao.cpp
@@ -1,6 +1,6 @@
 #include "./plantacao.hpp"
 #include "./terreno.hpp"
-#include <boost/uuid.hpp>
+#include "util/id.hpp"
 #include <chrono>
 #include <memory>
 
@@ -9,13 +9,10 @@ namespace Terrenos::Entidades
 
 Plantacao::Plantacao(std::unique_ptr<Planta> planta_,
                      std::unique_ptr<Terreno> terreno)
-    : dataDeInicio(Plantacao::obtenhaTempoAtual()), planta(std::move(planta_)),
+    : id(Utils::GeradorDeId::gerarUUID()),
+      dataDeInicio(Plantacao::obtenhaTempoAtual()), planta(std::move(planta_)),
       terreno(std::move(terreno))
 {
-
-    boost::uuids::random_generator uuidGenerator;
-    std::string strUuid = boost::uuids::to_string(uuidGenerator());
-    this->id = std::move(strUuid);
 }
 
 time_t Plantacao::obtenhaTempoAtual()

--- a/src/dominio/terrenos/entidades/plantacao.cpp
+++ b/src/dominio/terrenos/entidades/plantacao.cpp
@@ -1,5 +1,6 @@
 #include "./plantacao.hpp"
 #include "./terreno.hpp"
+#include "util/datas.hpp"
 #include "util/id.hpp"
 #include <chrono>
 #include <memory>
@@ -10,16 +11,9 @@ namespace Terrenos::Entidades
 Plantacao::Plantacao(std::unique_ptr<Planta> planta_,
                      std::unique_ptr<Terreno> terreno)
     : id(Utils::GeradorDeId::gerarUUID()),
-      dataDeInicio(Plantacao::obtenhaTempoAtual()), planta(std::move(planta_)),
-      terreno(std::move(terreno))
+      dataDeInicio(Utils::DataHora::obtenhaDataHoraAtual()),
+      planta(std::move(planta_)), terreno(std::move(terreno))
 {
-}
-
-time_t Plantacao::obtenhaTempoAtual()
-{
-    auto now = std::chrono::system_clock::now();
-    auto nowTimeT = std::chrono::system_clock::to_time_t(now);
-    return nowTimeT;
 }
 
 const std::string& Plantacao::obtenhaId() const
@@ -54,12 +48,12 @@ const Terreno& Plantacao::obtenhaTerreno() const
 
 void Plantacao::cancele()
 {
-    this->dataDeDesistencia = Plantacao::obtenhaTempoAtual();
+    this->dataDeDesistencia = Utils::DataHora::obtenhaDataHoraAtual();
 }
 
 void Plantacao::finalize()
 {
-    this->dataDeFinalizacao = Plantacao::obtenhaTempoAtual();
+    this->dataDeFinalizacao = Utils::DataHora::obtenhaDataHoraAtual();
 }
 
 } // namespace Terrenos::Entidades

--- a/src/dominio/terrenos/entidades/plantacao.hpp
+++ b/src/dominio/terrenos/entidades/plantacao.hpp
@@ -25,8 +25,6 @@ class Plantacao
     std::unique_ptr<Planta> planta;
     std::unique_ptr<Terreno> terreno;
 
-    static time_t obtenhaTempoAtual();
-
   public:
     Plantacao(std::unique_ptr<Planta> planta, std::unique_ptr<Terreno> terreno);
 

--- a/src/dominio/terrenos/entidades/terreno.cpp
+++ b/src/dominio/terrenos/entidades/terreno.cpp
@@ -1,5 +1,5 @@
 #include "./terreno.hpp"
-#include <boost/uuid.hpp>
+#include "util/id.hpp"
 #include <iostream>
 
 namespace Terrenos::Entidades
@@ -9,12 +9,9 @@ Terreno::Terreno(unsigned int largura_,
                  unsigned int comprimento_,
                  Terrenos::Enums::ExposicaoSolar exposicaoSolar_,
                  Terrenos::Enums::Clima clima_)
-    : largura(largura_), comprimento(comprimento_),
-      exposicaoSolar(exposicaoSolar_), clima(clima_)
+    : id(Utils::GeradorDeId::gerarUUID()), largura(largura_),
+      comprimento(comprimento_), exposicaoSolar(exposicaoSolar_), clima(clima_)
 {
-    boost::uuids::random_generator uuidGenerator;
-    std::string strUuid = boost::uuids::to_string(uuidGenerator());
-    this->id = std::move(strUuid);
 }
 
 const std::string& Terreno::obtenhaId() const

--- a/src/util/data.cpp
+++ b/src/util/data.cpp
@@ -1,0 +1,14 @@
+#include "datas.hpp"
+#include <chrono>
+
+namespace Utils::DataHora
+{
+
+time_t obtenhaDataHoraAtual()
+{
+    auto now = std::chrono::system_clock::now();
+    auto nowTimeT = std::chrono::system_clock::to_time_t(now);
+    return nowTimeT;
+}
+
+} // namespace Utils::DataHora

--- a/src/util/datas.hpp
+++ b/src/util/datas.hpp
@@ -1,0 +1,10 @@
+#pragma once
+
+#include <ctime>
+
+namespace Utils::DataHora
+{
+
+time_t obtenhaDataHoraAtual();
+
+} // namespace Utils::DataHora

--- a/src/util/id.cpp
+++ b/src/util/id.cpp
@@ -1,0 +1,14 @@
+#include "id.hpp"
+#include <boost/uuid.hpp>
+
+namespace Utils::GeradorDeId
+{
+
+std::string gerarUUID()
+{
+    boost::uuids::random_generator uuGeradorDeId;
+    std::string strUuid = boost::uuids::to_string(uuGeradorDeId());
+    return strUuid;
+}
+
+} // namespace Utils::GeradorDeId

--- a/src/util/id.hpp
+++ b/src/util/id.hpp
@@ -1,0 +1,17 @@
+#pragma once
+
+#include <string>
+
+// Observação: classes utilitárias não deveriam ser instanciadas nem extendidas.
+// Fazer classes com membros estáticos para servirem de classes "utilitárias" é
+// uma solução que, porém, permite esse comportamento inesperado.
+//
+// Uma alternativa é combinar namespaces com simples funções.
+// Leia: https://stackoverflow.com/a/112451/20361836
+
+namespace Utils::GeradorDeId
+{
+
+std::string gerarUUID();
+
+} // namespace Utils::GeradorDeId


### PR DESCRIPTION
- Adiciona o método `Utils::GeradorDeId::gerarUUID` e substitui criação de IDs locais por ele;
- Adiciona o método `Utils::DataHora::obtenhaDataHoraAtual` e substitui métodos estáticos locais de criação de hora por ele.