### PR TITLE
feat: gerente de terrenos

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@
 - [ ] `marqueComoResolvida`;
 - [ ] `listePlantas`;
 - [ ] `adicionePlantacao`;
-- [ ] `obtenhaSugestoes`;
+- [x] `obtenhaSugestoes`;
 - [ ] `finalizePlantacao`;
 - [ ] `desistaDaPlantacao`;
 

--- a/README.md
+++ b/README.md
@@ -14,17 +14,22 @@
 - [ ] Adicionar Nova Plantação
 
 ### Operações implementadas
+**Dos casos de uso**
 - [x] `listeTerrenos`;
 - [x] `recebaDadosDoSolo`;
-- [ ] `denuncie`;
-- [ ] `listeDenuncias`;
-- [ ] `marqueComoInvestigando`;
-- [ ] `marqueComoResolvida`;
+- [x] `denuncie`;
+- [x] `listeDenuncias`;
+- [x] `marqueComoInvestigando`;
+- [x] `marqueComoResolvida`;
 - [ ] `listePlantas`;
 - [ ] `adicionePlantacao`;
+
+**Extras**
 - [x] `obtenhaSugestoes`;
 - [ ] `finalizePlantacao`;
 - [ ] `desistaDaPlantacao`;
+- [x] `denuncie`
+- [x] `obtenhaDenuncia`
 
 ## Primeiros passos
 Para rodar o projeto, são necessárias ferramentas para baixar as dependências do sistema,

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
 - [ ] Adicionar Nova Plantação
 
 ### Operações implementadas
-- [ ] `listeTerrenos`;
+- [x] `listeTerrenos`;
 - [ ] `recebaDadosDoSolo`;
 - [ ] `denuncie`;
 - [ ] `listeDenuncias`;

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
 
 ### Operações implementadas
 - [x] `listeTerrenos`;
-- [ ] `recebaDadosDoSolo`;
+- [x] `recebaDadosDoSolo`;
 - [ ] `denuncie`;
 - [ ] `listeDenuncias`;
 - [ ] `marqueComoInvestigando`;

--- a/src/dominio/terrenos/dao/plantas_dao.hpp
+++ b/src/dominio/terrenos/dao/plantas_dao.hpp
@@ -12,7 +12,7 @@ namespace Terrenos::Dao
 class PlantasDao
 {
   public:
-    virtual std::vector<std::shared_ptr<Entidades::Planta>>
+    virtual std::vector<Entidades::Planta>
     encontrePlantasCorrespondentes(const Entidades::Solo& solo) = 0;
 
     virtual std::optional<std::shared_ptr<Entidades::Planta>>

--- a/src/dominio/terrenos/dao/plantas_dao.hpp
+++ b/src/dominio/terrenos/dao/plantas_dao.hpp
@@ -13,7 +13,7 @@ class PlantasDao
 {
   public:
     virtual std::vector<std::shared_ptr<Entidades::Planta>>
-    encontrePlantasCorrespondentes(Entidades::Solo& solo) = 0;
+    encontrePlantasCorrespondentes(const Entidades::Solo& solo) = 0;
 
     virtual std::optional<std::shared_ptr<Entidades::Planta>>
     encontre(const std::string& idPlanta) = 0;

--- a/src/dominio/terrenos/dao/terrenos_dao.hpp
+++ b/src/dominio/terrenos/dao/terrenos_dao.hpp
@@ -12,7 +12,7 @@ namespace Terrenos::Dao
 class TerrenosDao
 {
   public:
-    virtual std::optional<std::shared_ptr<Entidades::Terreno>>
+    virtual std::optional<Entidades::Terreno>
     encontre(const std::string& idTerreno) const = 0;
 
     virtual std::unique_ptr<Entidades::Solo>

--- a/src/dominio/terrenos/dao/terrenos_dao.hpp
+++ b/src/dominio/terrenos/dao/terrenos_dao.hpp
@@ -27,8 +27,7 @@ class TerrenosDao
 
     virtual void salve(Entidades::Terreno terreno) = 0;
 
-    virtual std::vector<std::shared_ptr<Entidades::Terreno>>
-    listeTodosDoUsuario(
+    virtual std::vector<Entidades::Terreno> listeTodosDoUsuario(
         const Identidade::Entidades::Usuario& usuario) const = 0;
 };
 

--- a/src/dominio/terrenos/dao/terrenos_dao.hpp
+++ b/src/dominio/terrenos/dao/terrenos_dao.hpp
@@ -16,8 +16,7 @@ class TerrenosDao
     encontre(const std::string& idTerreno) const = 0;
 
     virtual std::shared_ptr<Entidades::Solo>
-    crieSolo(const std::string& idTerreno,
-             double acidez,
+    crieSolo(double acidez,
              unsigned int indiceDeMinerais,
              unsigned int indiceDeSalinidade,
              unsigned int indiceDeArgila,

--- a/src/dominio/terrenos/dao/terrenos_dao.hpp
+++ b/src/dominio/terrenos/dao/terrenos_dao.hpp
@@ -15,7 +15,7 @@ class TerrenosDao
     virtual std::optional<std::shared_ptr<Entidades::Terreno>>
     encontre(const std::string& idTerreno) const = 0;
 
-    virtual std::shared_ptr<Entidades::Solo>
+    virtual std::unique_ptr<Entidades::Solo>
     crieSolo(double acidez,
              unsigned int indiceDeMinerais,
              unsigned int indiceDeSalinidade,

--- a/src/dominio/terrenos/dvo/terrenos_dvo.cpp
+++ b/src/dominio/terrenos/dvo/terrenos_dvo.cpp
@@ -5,7 +5,7 @@ namespace Terrenos::Dvo
 {
 
 void TerrenosDvo::valideSolo(
-    std::shared_ptr<const Entidades::Solo>& solo) noexcept(false)
+    const std::shared_ptr<const Entidades::Solo>& solo) noexcept(false)
 {
     const unsigned char LIMITE_DO_INTERVALO = 100;
 

--- a/src/dominio/terrenos/dvo/terrenos_dvo.cpp
+++ b/src/dominio/terrenos/dvo/terrenos_dvo.cpp
@@ -4,26 +4,25 @@
 namespace Terrenos::Dvo
 {
 
-void TerrenosDvo::valideSolo(
-    const std::shared_ptr<const Entidades::Solo>& solo) noexcept(false)
+void TerrenosDvo::valideSolo(const Entidades::Solo& solo) noexcept(false)
 {
     const unsigned char LIMITE_DO_INTERVALO = 100;
 
-    if (solo->obtenhaAcidez() < 0)
+    if (solo.obtenhaAcidez() < 0)
     {
         throw std::invalid_argument("A acidez do solo não pode ser negativa.");
     }
 
-    if (solo->obtenhaIndiceDeAreia() > LIMITE_DO_INTERVALO ||
-        solo->obtenhaIndiceDeArgila() > LIMITE_DO_INTERVALO ||
-        solo->obtenhaIndiceDeMinerais() > LIMITE_DO_INTERVALO ||
-        solo->obtenhaIndiceDeSalinidade() > LIMITE_DO_INTERVALO ||
-        solo->obtenhaIndiceDeSilte() > LIMITE_DO_INTERVALO)
+    if (solo.obtenhaIndiceDeAreia() > LIMITE_DO_INTERVALO ||
+        solo.obtenhaIndiceDeArgila() > LIMITE_DO_INTERVALO ||
+        solo.obtenhaIndiceDeMinerais() > LIMITE_DO_INTERVALO ||
+        solo.obtenhaIndiceDeSalinidade() > LIMITE_DO_INTERVALO ||
+        solo.obtenhaIndiceDeSilte() > LIMITE_DO_INTERVALO)
     {
         throw std::range_error("Os índices devem estar entre 0 e 100.");
     }
 
-    if (solo->obtenhaCargaEletrica() < 0)
+    if (solo.obtenhaCargaEletrica() < 0)
     {
         throw std::invalid_argument("A carga elétrica não pode ser negativa.");
     }

--- a/src/dominio/terrenos/dvo/terrenos_dvo.hpp
+++ b/src/dominio/terrenos/dvo/terrenos_dvo.hpp
@@ -7,8 +7,7 @@ namespace Terrenos::Dvo
 class TerrenosDvo
 {
   public:
-    static void valideSolo(
-        const std::shared_ptr<const Entidades::Solo>& solo) noexcept(false);
+    static void valideSolo(const Entidades::Solo& solo) noexcept(false);
 };
 
 } // namespace Terrenos::Dvo

--- a/src/dominio/terrenos/dvo/terrenos_dvo.hpp
+++ b/src/dominio/terrenos/dvo/terrenos_dvo.hpp
@@ -7,8 +7,8 @@ namespace Terrenos::Dvo
 class TerrenosDvo
 {
   public:
-    static void
-    valideSolo(std::shared_ptr<const Entidades::Solo>& solo) noexcept(false);
+    static void valideSolo(
+        const std::shared_ptr<const Entidades::Solo>& solo) noexcept(false);
 };
 
 } // namespace Terrenos::Dvo

--- a/src/dominio/terrenos/entidades/terreno.cpp
+++ b/src/dominio/terrenos/entidades/terreno.cpp
@@ -17,6 +17,18 @@ Terreno::Terreno(unsigned int largura_,
 {
 }
 
+Terreno::Terreno(const Terreno& terreno)
+    : id(terreno.id), largura(terreno.largura),
+      comprimento(terreno.comprimento),
+      solo(terreno.solo.has_value()
+               ? std::make_optional(
+                     std::make_unique<Entidades::Solo>(**terreno.solo))
+               : std::nullopt),
+      exposicaoSolar(terreno.exposicaoSolar), clima(terreno.clima),
+      plantacaoAtiva(terreno.plantacaoAtiva), proprietario(terreno.proprietario)
+{
+}
+
 const std::string& Terreno::obtenhaId() const
 {
     return this->id;

--- a/src/dominio/terrenos/entidades/terreno.hpp
+++ b/src/dominio/terrenos/entidades/terreno.hpp
@@ -36,6 +36,8 @@ class Terreno
             Terrenos::Enums::Clima clima,
             std::shared_ptr<Identidade::Entidades::Usuario> proprietario);
 
+    Terreno(const Terreno& terreno);
+
     const std::string& obtenhaId() const;
     unsigned int obtenhaLargura() const;
     unsigned int obtenhaComprimento() const;

--- a/src/dominio/terrenos/gerentes/gerente_de_terrenos.cpp
+++ b/src/dominio/terrenos/gerentes/gerente_de_terrenos.cpp
@@ -1,0 +1,63 @@
+#include "gerente_de_terrenos.hpp"
+#include "dominio/terrenos/dao/plantas_dao.hpp"
+#include "dominio/terrenos/dao/terrenos_dao.hpp"
+#include <algorithm>
+#include <stdexcept>
+
+namespace Terrenos::Gerentes
+{
+
+GerenteDeTerrenos::GerenteDeTerrenos(
+    std::shared_ptr<Roteador::Contexto> contexto_)
+    : contexto(std::move(contexto_))
+{
+}
+
+std::vector<Entidades::Planta>
+GerenteDeTerrenos::obtenhaSugestoes(const std::string& idTerreno) const
+{
+    using Terrenos::Dao::PlantasDao;
+    using Terrenos::Dao::TerrenosDao;
+    using Terrenos::Entidades::Planta;
+
+    auto terrenosDao = this->contexto->obtenha<TerrenosDao>();
+    auto plantasDao = this->contexto->obtenha<PlantasDao>();
+
+    auto terrenoEncontrado = terrenosDao->encontre(idTerreno);
+
+    if (!terrenoEncontrado)
+    {
+        throw std::invalid_argument(
+            "Não foi possível encontrar um terreno com id \"" + idTerreno +
+            "\".");
+    }
+
+    auto terreno = *terrenoEncontrado;
+    const auto& solo = terreno->obtenhaSolo();
+
+    if (!solo.has_value())
+    {
+        throw std::invalid_argument("O terreno deve ter informações do seu "
+                                    "solo registrado para prosseguir.");
+    }
+
+    auto plantas = plantasDao->encontrePlantasCorrespondentes(**solo);
+    return plantas;
+}
+
+std::vector<Entidades::Terreno>
+GerenteDeTerrenos::listeTerrenos(const std::string& idUsuario) const
+{
+}
+
+void GerenteDeTerrenos::recebaDadosDoSolo(std::string idTerreno,
+                                          float acidez,
+                                          unsigned char índiceDeMinerais,
+                                          unsigned char índiceDeSalinidade,
+                                          unsigned char índiceDeArgila,
+                                          unsigned char índiceDeSilte,
+                                          unsigned char cargaElétrica)
+{
+}
+
+} // namespace Terrenos::Gerentes

--- a/src/dominio/terrenos/gerentes/gerente_de_terrenos.cpp
+++ b/src/dominio/terrenos/gerentes/gerente_de_terrenos.cpp
@@ -1,4 +1,5 @@
 #include "gerente_de_terrenos.hpp"
+#include "dominio/identidade/dao/usuarios_dao.hpp"
 #include "dominio/terrenos/dao/plantas_dao.hpp"
 #include "dominio/terrenos/dao/terrenos_dao.hpp"
 #include <algorithm>
@@ -48,6 +49,25 @@ GerenteDeTerrenos::obtenhaSugestoes(const std::string& idTerreno) const
 std::vector<Entidades::Terreno>
 GerenteDeTerrenos::listeTerrenos(const std::string& idUsuario) const
 {
+    using Identidade::Dao::UsuariosDao;
+    using Identidade::Entidades::Usuario;
+    using Terrenos::Dao::TerrenosDao;
+
+    auto terrenosDao = this->contexto->obtenha<TerrenosDao>();
+    auto usuariosDao = this->contexto->obtenha<UsuariosDao>();
+
+    auto usuarioEncontrado = usuariosDao->encontre(idUsuario);
+
+    if (!usuarioEncontrado)
+    {
+        throw std::invalid_argument("Nâo existe um usuário com id \"" +
+                                    idUsuario + "\".");
+    }
+
+    auto usuario = std::dynamic_pointer_cast<Usuario>(*usuarioEncontrado);
+    auto terrenos = terrenosDao->listeTodosDoUsuario(*usuario);
+
+    return terrenos;
 }
 
 void GerenteDeTerrenos::recebaDadosDoSolo(std::string idTerreno,

--- a/src/dominio/terrenos/gerentes/gerente_de_terrenos.hpp
+++ b/src/dominio/terrenos/gerentes/gerente_de_terrenos.hpp
@@ -1,0 +1,32 @@
+#include "dominio/terrenos/entidades/planta.hpp"
+#include "dominio/terrenos/entidades/terreno.hpp"
+#include "roteador.hpp"
+#include <vector>
+
+namespace Terrenos::Gerentes
+{
+
+class GerenteDeTerrenos
+{
+  private:
+    std::shared_ptr<Roteador::Contexto> contexto;
+
+  public:
+    GerenteDeTerrenos(std::shared_ptr<Roteador::Contexto> contexto);
+
+    std::vector<Entidades::Planta>
+    obtenhaSugestoes(const std::string& idTerreno) const;
+
+    std::vector<Entidades::Terreno>
+    listeTerrenos(const std::string& idUsuario) const;
+
+    void recebaDadosDoSolo(std::string idTerreno,
+                           float acidez,
+                           unsigned char índiceDeMinerais,
+                           unsigned char índiceDeSalinidade,
+                           unsigned char índiceDeArgila,
+                           unsigned char índiceDeSilte,
+                           unsigned char cargaElétrica);
+};
+
+} // namespace Terrenos::Gerentes

--- a/src/dominio/terrenos/gerentes/gerente_de_terrenos.hpp
+++ b/src/dominio/terrenos/gerentes/gerente_de_terrenos.hpp
@@ -22,11 +22,11 @@ class GerenteDeTerrenos
 
     void recebaDadosDoSolo(std::string idTerreno,
                            float acidez,
-                           unsigned char índiceDeMinerais,
-                           unsigned char índiceDeSalinidade,
-                           unsigned char índiceDeArgila,
-                           unsigned char índiceDeSilte,
-                           unsigned char cargaElétrica);
+                           unsigned char indiceDeMinerais,
+                           unsigned char indiceDeSalinidade,
+                           unsigned char indiceDeArgila,
+                           unsigned char indiceDeSilte,
+                           unsigned char cargaEletrica);
 };
 
 } // namespace Terrenos::Gerentes

--- a/src/infra/dao/em_memoria/plantas_dao_em_memoria.cpp
+++ b/src/infra/dao/em_memoria/plantas_dao_em_memoria.cpp
@@ -11,7 +11,7 @@ namespace Daos::EmMemoria
 {
 
 std::vector<std::shared_ptr<Planta>>
-PlantasDaoEmMemoria::encontrePlantasCorrespondentes(Solo& solo)
+PlantasDaoEmMemoria::encontrePlantasCorrespondentes(const Solo& solo)
 {
     std::lock_guard<std::mutex> lock(*Globais::plantasDbMutex);
 

--- a/src/infra/dao/em_memoria/plantas_dao_em_memoria.cpp
+++ b/src/infra/dao/em_memoria/plantas_dao_em_memoria.cpp
@@ -10,19 +10,23 @@ using Terrenos::Entidades::Solo;
 namespace Daos::EmMemoria
 {
 
-std::vector<std::shared_ptr<Planta>>
+std::vector<Planta>
 PlantasDaoEmMemoria::encontrePlantasCorrespondentes(const Solo& solo)
 {
     std::lock_guard<std::mutex> lock(*Globais::plantasDbMutex);
 
-    std::vector<std::shared_ptr<Planta>> plantasCompativeis;
+    auto plantasCompativeis = std::vector<Planta>();
 
-    std::copy_if(
+    std::for_each(
         Globais::plantasDb->begin(),
         Globais::plantasDb->end(),
-        std::back_insert_iterator(plantasCompativeis),
-        [ &solo ](const std::shared_ptr<Planta>& planta)
-        { return PlantasDaoEmMemoria::plantaEhCompativel(*planta, solo); });
+        [ &solo, &plantasCompativeis ](const std::shared_ptr<Planta>& planta)
+        {
+            if (PlantasDaoEmMemoria::plantaEhCompativel(*planta, solo))
+            {
+                plantasCompativeis.push_back(*planta);
+            }
+        });
 
     return plantasCompativeis;
 }

--- a/src/infra/dao/em_memoria/plantas_dao_em_memoria.hpp
+++ b/src/infra/dao/em_memoria/plantas_dao_em_memoria.hpp
@@ -9,7 +9,7 @@ class PlantasDaoEmMemoria : public Terrenos::Dao::PlantasDao
 {
   public:
     std::vector<std::shared_ptr<Terrenos::Entidades::Planta>>
-    encontrePlantasCorrespondentes(Terrenos::Entidades::Solo& solo) final;
+    encontrePlantasCorrespondentes(const Terrenos::Entidades::Solo& solo) final;
 
     std::optional<std::shared_ptr<Terrenos::Entidades::Planta>>
     encontre(const std::string& idPlanta) final;

--- a/src/infra/dao/em_memoria/plantas_dao_em_memoria.hpp
+++ b/src/infra/dao/em_memoria/plantas_dao_em_memoria.hpp
@@ -8,7 +8,7 @@ namespace Daos::EmMemoria
 class PlantasDaoEmMemoria : public Terrenos::Dao::PlantasDao
 {
   public:
-    std::vector<std::shared_ptr<Terrenos::Entidades::Planta>>
+    std::vector<Terrenos::Entidades::Planta>
     encontrePlantasCorrespondentes(const Terrenos::Entidades::Solo& solo) final;
 
     std::optional<std::shared_ptr<Terrenos::Entidades::Planta>>

--- a/src/infra/dao/em_memoria/terrenos_dao_em_memoria.cpp
+++ b/src/infra/dao/em_memoria/terrenos_dao_em_memoria.cpp
@@ -29,7 +29,7 @@ TerrenosDaoEmMemoria::encontre(const std::string& idTerreno) const
     return *terrenoEncontrado;
 }
 
-std::shared_ptr<Terrenos::Entidades::Solo>
+std::unique_ptr<Terrenos::Entidades::Solo>
 TerrenosDaoEmMemoria::crieSolo(double acidez,
                                unsigned int indiceDeMinerais,
                                unsigned int indiceDeSalinidade,
@@ -39,7 +39,7 @@ TerrenosDaoEmMemoria::crieSolo(double acidez,
                                double cargaEletrica)
 {
     using Terrenos::Entidades::Solo;
-    auto solo = std::make_shared<Solo>(acidez,
+    auto solo = std::make_unique<Solo>(acidez,
                                        indiceDeMinerais,
                                        indiceDeSalinidade,
                                        indiceDeArgila,

--- a/src/infra/dao/em_memoria/terrenos_dao_em_memoria.cpp
+++ b/src/infra/dao/em_memoria/terrenos_dao_em_memoria.cpp
@@ -5,7 +5,7 @@
 namespace Daos::EmMemoria
 {
 
-std::optional<std::shared_ptr<Terrenos::Entidades::Terreno>>
+std::optional<Terrenos::Entidades::Terreno>
 TerrenosDaoEmMemoria::encontre(const std::string& idTerreno) const
 {
     using Globais::terrenosDb;
@@ -26,7 +26,7 @@ TerrenosDaoEmMemoria::encontre(const std::string& idTerreno) const
         return std::nullopt;
     }
 
-    return *terrenoEncontrado;
+    return **terrenoEncontrado;
 }
 
 std::unique_ptr<Terrenos::Entidades::Solo>

--- a/src/infra/dao/em_memoria/terrenos_dao_em_memoria.cpp
+++ b/src/infra/dao/em_memoria/terrenos_dao_em_memoria.cpp
@@ -30,8 +30,7 @@ TerrenosDaoEmMemoria::encontre(const std::string& idTerreno) const
 }
 
 std::shared_ptr<Terrenos::Entidades::Solo>
-TerrenosDaoEmMemoria::crieSolo(const std::string& idTerreno,
-                               double acidez,
+TerrenosDaoEmMemoria::crieSolo(double acidez,
                                unsigned int indiceDeMinerais,
                                unsigned int indiceDeSalinidade,
                                unsigned int indiceDeArgila,

--- a/src/infra/dao/em_memoria/terrenos_dao_em_memoria.cpp
+++ b/src/infra/dao/em_memoria/terrenos_dao_em_memoria.cpp
@@ -78,7 +78,7 @@ void TerrenosDaoEmMemoria::salve(Terrenos::Entidades::Terreno terreno)
     terrenosDb->push_back(terrenoCompartilhado);
 }
 
-std::vector<std::shared_ptr<Terrenos::Entidades::Terreno>>
+std::vector<Terrenos::Entidades::Terreno>
 TerrenosDaoEmMemoria::listeTodosDoUsuario(
     const Identidade::Entidades::Usuario& usuario) const
 {
@@ -87,7 +87,7 @@ TerrenosDaoEmMemoria::listeTodosDoUsuario(
     using Identidade::Entidades::Usuario;
     using Terrenos::Entidades::Terreno;
 
-    auto terrenosDoUsuario = std::vector<std::shared_ptr<Terreno>>();
+    auto terrenosDoUsuario = std::vector<Terreno>();
     auto idUsuario = usuario.obtenhaId();
     std::lock_guard<std::mutex> lock(*terrenosDbMutex);
 
@@ -99,7 +99,7 @@ TerrenosDaoEmMemoria::listeTodosDoUsuario(
         {
             if (terreno->obtenhaProprietario()->obtenhaId() == idUsuario)
             {
-                terrenosDoUsuario.push_back(terreno);
+                terrenosDoUsuario.push_back(*terreno);
             }
         });
 

--- a/src/infra/dao/em_memoria/terrenos_dao_em_memoria.hpp
+++ b/src/infra/dao/em_memoria/terrenos_dao_em_memoria.hpp
@@ -20,8 +20,7 @@ class TerrenosDaoEmMemoria : public Terrenos::Dao::TerrenosDao
 
     void salve(Terrenos::Entidades::Terreno terreno) final;
 
-    std::vector<std::shared_ptr<Terrenos::Entidades::Terreno>>
-    listeTodosDoUsuario(
+    std::vector<Terrenos::Entidades::Terreno> listeTodosDoUsuario(
         const Identidade::Entidades::Usuario& usuario) const final;
 };
 

--- a/src/infra/dao/em_memoria/terrenos_dao_em_memoria.hpp
+++ b/src/infra/dao/em_memoria/terrenos_dao_em_memoria.hpp
@@ -9,8 +9,7 @@ class TerrenosDaoEmMemoria : public Terrenos::Dao::TerrenosDao
     encontre(const std::string& idTerreno) const final;
 
     std::shared_ptr<Terrenos::Entidades::Solo>
-    crieSolo(const std::string& idTerreno,
-             double acidez,
+    crieSolo(double acidez,
              unsigned int indiceDeMinerais,
              unsigned int indiceDeSalinidade,
              unsigned int indiceDeArgila,

--- a/src/infra/dao/em_memoria/terrenos_dao_em_memoria.hpp
+++ b/src/infra/dao/em_memoria/terrenos_dao_em_memoria.hpp
@@ -8,7 +8,7 @@ class TerrenosDaoEmMemoria : public Terrenos::Dao::TerrenosDao
     std::optional<std::shared_ptr<Terrenos::Entidades::Terreno>>
     encontre(const std::string& idTerreno) const final;
 
-    std::shared_ptr<Terrenos::Entidades::Solo>
+    std::unique_ptr<Terrenos::Entidades::Solo>
     crieSolo(double acidez,
              unsigned int indiceDeMinerais,
              unsigned int indiceDeSalinidade,

--- a/src/infra/dao/em_memoria/terrenos_dao_em_memoria.hpp
+++ b/src/infra/dao/em_memoria/terrenos_dao_em_memoria.hpp
@@ -5,7 +5,7 @@ namespace Daos::EmMemoria
 
 class TerrenosDaoEmMemoria : public Terrenos::Dao::TerrenosDao
 {
-    std::optional<std::shared_ptr<Terrenos::Entidades::Terreno>>
+    std::optional<Terrenos::Entidades::Terreno>
     encontre(const std::string& idTerreno) const final;
 
     std::unique_ptr<Terrenos::Entidades::Solo>


### PR DESCRIPTION
## Adicionados
- `GerenteDeTerrenos` + implementações;
- construtor de "cópia" na entidade `Terreno`.

## Alterados
- torna o parâmetro de `PlantasDao::encontrePlantasCorrespondentes` constante;
- muda o retorno de métodos que retornam ponteiros compartlihados de entidades para retornarem cópias delas diretamente.