### PR TITLE
change(DAOs): retorna sempre cópias das entidades ao invés de referências às instâncias originais

### DIFF
--- a/src/dominio/moderacao/dao/denuncias_dao.hpp
+++ b/src/dominio/moderacao/dao/denuncias_dao.hpp
@@ -9,7 +9,7 @@ namespace Moderacao::Dao
 class DenunciasDao
 {
   public:
-    virtual std::vector<std::shared_ptr<Entidades::Denuncia>> liste() const = 0;
+    virtual std::vector<Entidades::Denuncia> liste() const = 0;
 
     virtual std::shared_ptr<Entidades::Denuncia>
     crie(Enums::MotivoDaDenuncia motivo,
@@ -19,7 +19,7 @@ class DenunciasDao
 
     virtual void salve(Entidades::Denuncia denuncia) = 0;
 
-    virtual std::optional<std::shared_ptr<Entidades::Denuncia>>
+    virtual std::optional<Entidades::Denuncia>
     encontre(const std::string& idDenuncia) const = 0;
 };
 

--- a/src/dominio/moderacao/gerentes/gerente_de_denuncias.cpp
+++ b/src/dominio/moderacao/gerentes/gerente_de_denuncias.cpp
@@ -16,12 +16,6 @@ GerenteDeDenuncias::listeDenuncias() const
     auto denuncias = denunciasDao->liste();
     std::vector<Denuncia> denunciasCopiadas;
 
-    std::transform(denuncias.begin(),
-                   denuncias.end(),
-                   std::back_inserter(denunciasCopiadas),
-                   [](const std::shared_ptr<Denuncia>& denuncia)
-                   { return *denuncia; });
-
     return denunciasCopiadas;
 }
 
@@ -39,7 +33,7 @@ GerenteDeDenuncias::obtenhaDenuncia(std::string& idDenuncia) const
         return std::nullopt;
     }
 
-    return **denuncia;
+    return *denuncia;
 }
 
 void GerenteDeDenuncias::denuncie(std::string idRelator,
@@ -88,7 +82,7 @@ void GerenteDeDenuncias::marqueComoInvestigando(const std::string& idModerador,
     }
 
     auto moderador = std::dynamic_pointer_cast<Usuario>(*moderadorEncontrado);
-    auto denuncia = **denunciaEncontrada;
+    auto denuncia = *denunciaEncontrada;
 
     denuncia.coloqueModeradorInvestigador(std::move(moderador));
     denuncia.coloqueEstado(EstadoDaDenuncia::ANALISE);
@@ -131,7 +125,7 @@ void GerenteDeDenuncias::marqueComoResolvida(const std::string& idModerador,
 
     auto moderador = std::dynamic_pointer_cast<Usuario>(*moderadorEncontrado);
 
-    auto denuncia = **denunciaEncontrado;
+    auto denuncia = *denunciaEncontrado;
     denuncia.coloqueEstado(EstadoDaDenuncia::RESOLVIDO);
     denuncia.coloqueModeradorResolutor(moderador);
 

--- a/src/dominio/terrenos/dao/plantas_dao.hpp
+++ b/src/dominio/terrenos/dao/plantas_dao.hpp
@@ -15,7 +15,7 @@ class PlantasDao
     virtual std::vector<Entidades::Planta>
     encontrePlantasCorrespondentes(const Entidades::Solo& solo) = 0;
 
-    virtual std::optional<std::shared_ptr<Entidades::Planta>>
+    virtual std::optional<Entidades::Planta>
     encontre(const std::string& idPlanta) = 0;
 };
 

--- a/src/infra/dao/em_memoria/denuncias_dao_em_memoria.cpp
+++ b/src/infra/dao/em_memoria/denuncias_dao_em_memoria.cpp
@@ -8,11 +8,22 @@ namespace Daos::EmMemoria
 using Globais::denunciasDb;
 using Globais::denunciasDbMutex;
 
-std::vector<std::shared_ptr<Moderacao::Entidades::Denuncia>>
-DenunciasDaoEmMemoria::liste() const
+std::vector<Moderacao::Entidades::Denuncia> DenunciasDaoEmMemoria::liste() const
 {
+    using Moderacao::Entidades::Denuncia;
+
     std::lock_guard<std::mutex> lock(*denunciasDbMutex);
-    return *denunciasDb;
+
+    auto copiaDasDenuncias = std::vector<Denuncia>();
+    copiaDasDenuncias.reserve(denunciasDb->size());
+
+    std::for_each(
+        denunciasDb->begin(),
+        denunciasDb->end(),
+        [ &copiaDasDenuncias ](const std::shared_ptr<Denuncia>& denuncia)
+        { copiaDasDenuncias.push_back(*denuncia); });
+
+    return copiaDasDenuncias;
 }
 
 std::shared_ptr<Moderacao::Entidades::Denuncia> DenunciasDaoEmMemoria::crie(
@@ -57,7 +68,7 @@ void DenunciasDaoEmMemoria::salve(Moderacao::Entidades::Denuncia denuncia)
     denunciasDb->push_back(std::make_shared<Denuncia>(denuncia));
 }
 
-std::optional<std::shared_ptr<Moderacao::Entidades::Denuncia>>
+std::optional<Moderacao::Entidades::Denuncia>
 DenunciasDaoEmMemoria::encontre(const std::string& idDenuncia) const
 {
     using Moderacao::Entidades::Denuncia;
@@ -74,7 +85,7 @@ DenunciasDaoEmMemoria::encontre(const std::string& idDenuncia) const
 
     if (denunciaFoiEncontrada)
     {
-        return *denunciasIterator;
+        return **denunciasIterator;
     }
 
     return std::nullopt;

--- a/src/infra/dao/em_memoria/denuncias_dao_em_memoria.hpp
+++ b/src/infra/dao/em_memoria/denuncias_dao_em_memoria.hpp
@@ -8,8 +8,7 @@ namespace Daos::EmMemoria
 class DenunciasDaoEmMemoria : public Moderacao::Dao::DenunciasDao
 {
   public:
-    std::vector<std::shared_ptr<Moderacao::Entidades::Denuncia>>
-    liste() const final;
+    std::vector<Moderacao::Entidades::Denuncia> liste() const final;
 
     std::shared_ptr<Moderacao::Entidades::Denuncia>
     crie(Moderacao::Enums::MotivoDaDenuncia motivo,
@@ -20,7 +19,7 @@ class DenunciasDaoEmMemoria : public Moderacao::Dao::DenunciasDao
 
     void salve(Moderacao::Entidades::Denuncia denuncia) override;
 
-    std::optional<std::shared_ptr<Moderacao::Entidades::Denuncia>>
+    std::optional<Moderacao::Entidades::Denuncia>
     encontre(const std::string& idDenuncia) const override;
 };
 

--- a/src/infra/dao/em_memoria/plantas_dao_em_memoria.cpp
+++ b/src/infra/dao/em_memoria/plantas_dao_em_memoria.cpp
@@ -31,8 +31,7 @@ PlantasDaoEmMemoria::encontrePlantasCorrespondentes(const Solo& solo)
     return plantasCompativeis;
 }
 
-std::optional<std::shared_ptr<Planta>>
-PlantasDaoEmMemoria::encontre(const std::string& idPlanta)
+std::optional<Planta> PlantasDaoEmMemoria::encontre(const std::string& idPlanta)
 {
     std::lock_guard<std::mutex> lock(*Globais::plantasDbMutex);
 
@@ -46,7 +45,7 @@ PlantasDaoEmMemoria::encontre(const std::string& idPlanta)
 
     if (plantaFoiEncontrada)
     {
-        return *plantasIterator;
+        return **plantasIterator;
     }
 
     return std::nullopt;

--- a/src/infra/dao/em_memoria/plantas_dao_em_memoria.hpp
+++ b/src/infra/dao/em_memoria/plantas_dao_em_memoria.hpp
@@ -11,7 +11,7 @@ class PlantasDaoEmMemoria : public Terrenos::Dao::PlantasDao
     std::vector<Terrenos::Entidades::Planta>
     encontrePlantasCorrespondentes(const Terrenos::Entidades::Solo& solo) final;
 
-    std::optional<std::shared_ptr<Terrenos::Entidades::Planta>>
+    std::optional<Terrenos::Entidades::Planta>
     encontre(const std::string& idPlanta) final;
 
   private:

--- a/src/infra/dao/em_memoria/usuarios_dao_em_memoria.cpp
+++ b/src/infra/dao/em_memoria/usuarios_dao_em_memoria.cpp
@@ -23,7 +23,8 @@ UsuariosDaoEmMemoria::encontre(const std::string& idUsuario)
     bool usuarioFoiEncontrado = usuario != usuariosDb->end();
     if (usuarioFoiEncontrado)
     {
-        return *usuario;
+        auto copiaDoUsuario = **usuario;
+        return std::make_shared<Usuario>(copiaDoUsuario);
     }
 
     return std::nullopt;


### PR DESCRIPTION
## DAOs alterados:
- UsuariosDao;
- PlantasDao;

## Observação
Por utilizar covariância de retorno, o `UsuariosDao` não pode retornar a instância por valor. Por isso, apenas copia a instância e a retorna como um novo ponteiro compartilhado (`shared_ptr`).