### PR TITLE
change: gerentes

### DIFF
--- a/src/dominio/moderacao/gerentes/gerente_de_daos_de_denunciaveis.cpp
+++ b/src/dominio/moderacao/gerentes/gerente_de_daos_de_denunciaveis.cpp
@@ -4,13 +4,19 @@
 namespace Moderacao::Gerentes
 {
 
+GerenteDeDaosDeDenunciaveis::GerenteDeDaosDeDenunciaveis(
+    Roteador::Contexto& contexto_)
+    : contexto(contexto_)
+{
+}
+
 std::shared_ptr<Dao::DenunciavelDao>
 GerenteDeDaosDeDenunciaveis::obtenhaDao(Enums::TipoDoDenunciavel tipo) const
 {
     switch (tipo)
     {
     case Moderacao::Enums::TipoDoDenunciavel::USUARIO:
-        return this->contexto->obtenha<Identidade::Dao::UsuariosDao>();
+        return this->contexto.obtenha<Identidade::Dao::UsuariosDao>();
     default:
         throw std::runtime_error("Dao da entidade " +
                                  Enums::tipoDoDenunciavelParaString(tipo) +

--- a/src/dominio/moderacao/gerentes/gerente_de_daos_de_denunciaveis.hpp
+++ b/src/dominio/moderacao/gerentes/gerente_de_daos_de_denunciaveis.hpp
@@ -14,9 +14,11 @@ namespace Moderacao::Gerentes
 class GerenteDeDaosDeDenunciaveis
 {
   private:
-    std::shared_ptr<Roteador::Contexto> contexto;
+    Roteador::Contexto& contexto;
 
   public:
+    GerenteDeDaosDeDenunciaveis(Roteador::Contexto& contexto);
+
     std::shared_ptr<Dao::DenunciavelDao>
     obtenhaDao(Enums::TipoDoDenunciavel tipo) const;
 };

--- a/src/dominio/moderacao/gerentes/gerente_de_denuncias.cpp
+++ b/src/dominio/moderacao/gerentes/gerente_de_denuncias.cpp
@@ -6,13 +6,19 @@
 
 namespace Moderacao::Gerentes
 {
+
+GerenteDeDenuncias::GerenteDeDenuncias(Roteador::Contexto& contexto_)
+    : contexto(contexto_)
+{
+}
+
 std::vector<Moderacao::Entidades::Denuncia>
 GerenteDeDenuncias::listeDenuncias() const
 {
     using Moderacao::Dao::DenunciasDao;
     using Moderacao::Entidades::Denuncia;
 
-    auto denunciasDao = this->contexto->obtenha<DenunciasDao>();
+    auto denunciasDao = this->contexto.obtenha<DenunciasDao>();
     auto denuncias = denunciasDao->liste();
     std::vector<Denuncia> denunciasCopiadas;
 
@@ -25,7 +31,7 @@ GerenteDeDenuncias::obtenhaDenuncia(std::string& idDenuncia) const
     using Moderacao::Dao::DenunciasDao;
     using Moderacao::Entidades::Denuncia;
 
-    auto denunciasDao = this->contexto->obtenha<DenunciasDao>();
+    auto denunciasDao = this->contexto.obtenha<DenunciasDao>();
     auto denuncia = denunciasDao->encontre(idDenuncia);
 
     if (!denuncia)
@@ -45,7 +51,7 @@ void GerenteDeDenuncias::denuncie(std::string idRelator,
     using Moderacao::Dao::DenunciasDao;
     using Moderacao::Entidades::Denuncia;
 
-    auto denunciasDao = this->contexto->obtenha<DenunciasDao>();
+    auto denunciasDao = this->contexto.obtenha<DenunciasDao>();
 }
 
 void GerenteDeDenuncias::marqueComoInvestigando(const std::string& idModerador,
@@ -57,7 +63,7 @@ void GerenteDeDenuncias::marqueComoInvestigando(const std::string& idModerador,
     using Moderacao::Entidades::Denuncia;
     using Moderacao::Enums::EstadoDaDenuncia;
 
-    auto denunciasDao = this->contexto->obtenha<DenunciasDao>();
+    auto denunciasDao = this->contexto.obtenha<DenunciasDao>();
     auto denunciaEncontrada = denunciasDao->encontre(idDenuncia);
 
     if (!denunciaEncontrada)
@@ -69,7 +75,7 @@ void GerenteDeDenuncias::marqueComoInvestigando(const std::string& idModerador,
         return;
     }
 
-    auto usuariosDao = this->contexto->obtenha<UsuariosDao>();
+    auto usuariosDao = this->contexto.obtenha<UsuariosDao>();
     auto moderadorEncontrado = usuariosDao->encontre(idModerador);
 
     if (!moderadorEncontrado)
@@ -99,7 +105,7 @@ void GerenteDeDenuncias::marqueComoResolvida(const std::string& idModerador,
     using Moderacao::Entidades::Denuncia;
     using Moderacao::Enums::EstadoDaDenuncia;
 
-    auto denunciasDao = this->contexto->obtenha<DenunciasDao>();
+    auto denunciasDao = this->contexto.obtenha<DenunciasDao>();
     auto denunciaEncontrado = denunciasDao->encontre(idDenuncia);
 
     if (!denunciaEncontrado)
@@ -111,7 +117,7 @@ void GerenteDeDenuncias::marqueComoResolvida(const std::string& idModerador,
         return;
     }
 
-    auto usuariosDao = this->contexto->obtenha<UsuariosDao>();
+    auto usuariosDao = this->contexto.obtenha<UsuariosDao>();
     auto moderadorEncontrado = usuariosDao->encontre(idModerador);
 
     if (!moderadorEncontrado)

--- a/src/dominio/moderacao/gerentes/gerente_de_denuncias.hpp
+++ b/src/dominio/moderacao/gerentes/gerente_de_denuncias.hpp
@@ -10,9 +10,11 @@ namespace Moderacao::Gerentes
 class GerenteDeDenuncias
 {
   private:
-    std::shared_ptr<Roteador::Contexto> contexto;
+    Roteador::Contexto& contexto;
 
   public:
+    GerenteDeDenuncias(Roteador::Contexto& contexto);
+
     // Essas funções não retornam um `shared_ptr` porque, de fato, elas devem
     // copiar todas as Denuncias. Fornecendo o shared_ptr, as instâncias seriam
     // mutáveis e refletiriam diretamente no armazenamento em memória. Se a

--- a/src/dominio/terrenos/gerentes/gerente_de_plantas.cpp
+++ b/src/dominio/terrenos/gerentes/gerente_de_plantas.cpp
@@ -4,12 +4,17 @@
 namespace Terrenos::Gerentes
 {
 
+GerenteDePlantacoes::GerenteDePlantacoes(Roteador::Contexto& contexto_)
+    : contexto(contexto_)
+{
+}
+
 std::vector<Entidades::Planta> GerenteDePlantacoes::listePlantas() const
 {
     using Dao::PlantasDao;
     using Entidades::Planta;
 
-    auto plantasDao = this->contexto->obtenha<PlantasDao>();
+    auto plantasDao = this->contexto.obtenha<PlantasDao>();
     auto plantas = plantasDao->liste();
 
     return plantas;

--- a/src/dominio/terrenos/gerentes/gerente_de_plantas.hpp
+++ b/src/dominio/terrenos/gerentes/gerente_de_plantas.hpp
@@ -7,9 +7,10 @@ namespace Terrenos::Gerentes
 class GerenteDePlantacoes
 {
   private:
-    std::shared_ptr<Roteador::Contexto> contexto;
+    Roteador::Contexto& contexto;
 
   public:
+    GerenteDePlantacoes(Roteador::Contexto& contexto);
     std::vector<Entidades::Planta> listePlantas() const;
 };
 


### PR DESCRIPTION
Modifica todas as propriedades `contexto` nos gerentes para serem apenas uma referência ao invés de um ponteiro compartilhado